### PR TITLE
from api/auth to Api/auth

### DIFF
--- a/frontend/src/features/auth/PrivateRoute.jsx
+++ b/frontend/src/features/auth/PrivateRoute.jsx
@@ -6,7 +6,7 @@ import {
 	useLocation,
 	useNavigate,
 } from "react-router-dom";
-//import { verifyToken } from "../../api/Authentication";
+//import { verifyToken } from "../../Api/Authentication";
 import { useSelector } from "react-redux";
 import {
 	selectCurrentToken,

--- a/frontend/src/features/auth/PrivateRoute.jsx
+++ b/frontend/src/features/auth/PrivateRoute.jsx
@@ -20,7 +20,7 @@ import { useDispatch } from "react-redux";
 import {
 	useRefreshTokenMutation,
 	useVerifyTokenMutation,
-} from "../../api/Authentication";
+} from "../../Api/Authentication";
 import { setCredentials } from "../../features/auth/authSlice";
 
 export const PrivateRoutes = () => {

--- a/frontend/src/hooks/useCategory.jsx
+++ b/frontend/src/hooks/useCategory.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { selectCurrentToken } from "../features/auth/authSlice";
-import { readCategory, readCategories, createCategory, deleteCategory, updateCategory } from "../api/Categories";
+import { readCategory, readCategories, createCategory, deleteCategory, updateCategory } from "../Api/Categories";
 
 export function useFetchCategory(id) {
     const [categoryData, setCategoryData] = useState(null);

--- a/frontend/src/hooks/useClass.jsx
+++ b/frontend/src/hooks/useClass.jsx
@@ -7,7 +7,7 @@ import {
 	useUpdateClassMutation,
 	useReadClassesBySectionMutation,
 	useReadClassesByCourseMutation,
-} from "../api/Classes";
+} from "../Api/Classes";
 
 export function useFetchClass(id) {
 	const [readClass] = useReadClassMutation();

--- a/frontend/src/hooks/useComments.jsx
+++ b/frontend/src/hooks/useComments.jsx
@@ -5,7 +5,7 @@ import {
     useReadCommentMutation,
     useReadCommentsMutation,
     useReadCommentsForActivityMutation,
-} from "../api/Comment";
+} from "../Api/Comment";
 
 export function useFetchComment(id) {
     const { data: commentData } = useReadCommentMutation(id, { skip: !id });

--- a/frontend/src/hooks/useCourse.jsx
+++ b/frontend/src/hooks/useCourse.jsx
@@ -5,7 +5,7 @@ import {
     useCreateCourseMutation,
     useDeleteCourseMutation,
     useUpdateCourseMutation,
-} from "../api/Course";
+} from "../Api/Course";
 
 export function useFetchCourse(id) {
     const [readCourse] = useReadCourseMutation();

--- a/frontend/src/hooks/useStudent.jsx
+++ b/frontend/src/hooks/useStudent.jsx
@@ -8,7 +8,7 @@ import {
     useCreateStudentMutation,
     useDeleteStudentMutation,
     useUpdateStudentMutation,
-} from "../api/Student";
+} from "../Api/Student";
 
 export function useFetchStudent(id) {
     const [readStudent] = useReadStudentMutation();

--- a/frontend/src/hooks/useTeacher.jsx
+++ b/frontend/src/hooks/useTeacher.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { selectCurrentToken } from "../features/auth/authSlice";
-import { readTeacher, readTeachers, createTeacher, deleteTeacher, updateTeacher } from "../api/Teachers";
+import { readTeacher, readTeachers, createTeacher, deleteTeacher, updateTeacher } from "../Api/Teachers";
 
 export function useFetchTeacher(id) {
     const [teacherData, setTeacherData] = useState(null);

--- a/frontend/src/hooks/useTeam.jsx
+++ b/frontend/src/hooks/useTeam.jsx
@@ -5,7 +5,7 @@ import {
 	useCreateTeamMutation,
 	useDeleteTeamMutation,
 	useUpdateTeamMutation,
-} from "../api/Teams";
+} from "../Api/Teams";
 
 export function useFetchTeam(id) {
 	const [readTeam] = useReadTeamMutation();

--- a/frontend/src/hooks/useTemplate.jsx
+++ b/frontend/src/hooks/useTemplate.jsx
@@ -5,7 +5,7 @@ import {
     useCreateTemplateMutation,
     useDeleteTemplateMutation,
     useUpdateTemplateMutation,
-} from "../api/Template";
+} from "../Api/Template";
 
 export function useFetchTemplate(id) {
     const [readTemplate] = useReadTemplateMutation();

--- a/frontend/src/views/Student/SignIn.jsx
+++ b/frontend/src/views/Student/SignIn.jsx
@@ -7,7 +7,7 @@ import { Authentication } from "../../api/Authentication";
 import {
 	useLoginStudentMutation,
 	useAcquireTokenMutation,
-} from "../../api/Authentication";
+} from "../../Api/Authentication";
 import { setStudentModel } from "../../features/slice/studentModelSlice";
 import { saveToLocalStorage } from "../../components/utils/utils";
 

--- a/frontend/src/views/Student/SignIn.jsx
+++ b/frontend/src/views/Student/SignIn.jsx
@@ -3,7 +3,7 @@ import { useState, useRef, useEffect } from "react";
 import { useNavigate, Navigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
 import { setCredentials } from "../../features/auth/authSlice";
-import { Authentication } from "../../api/Authentication";
+import { Authentication } from "../../Api/Authentication";
 import {
 	useLoginStudentMutation,
 	useAcquireTokenMutation,

--- a/frontend/src/views/Teacher/SignIn.jsx
+++ b/frontend/src/views/Teacher/SignIn.jsx
@@ -6,7 +6,7 @@ import { setCredentials } from "../../features/auth/authSlice";
 import {
 	useLoginTeacherMutation,
 	useAcquireTokenMutation,
-} from "../../api/Authentication";
+} from "../../Api/Authentication";
 
 export const Teacher_SignIn = () => {
 	const userRef = useRef();


### PR DESCRIPTION
Fixed naming imports like `../api/<filename>` to `../Api/<filename>` to fix deployment build errors.
Here is the current latest app link. [App Site](https://activity-management-tool-charisarlie-baclayons-projects.vercel.app/)
